### PR TITLE
[msm8974] Use aosp gps hall

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -71,6 +71,11 @@ BOARD_HARDWARE_CLASS += device/sony/msm8974-common/cmhw
 # Font
 EXTENDED_FONT_FOOTPRINT := true
 
+# GPS definitions for Qualcomm solution
+BOARD_VENDOR_QCOM_GPS_LOC_API_HARDWARE := $(TARGET_BOARD_PLATFORM)
+BOARD_VENDOR_QCOM_LOC_PDK_FEATURE_SET := true
+TARGET_NO_RPC := true
+
 # Graphics
 USE_OPENGL_RENDERER := true
 TARGET_USES_ION := true

--- a/gps/gps.conf
+++ b/gps/gps.conf
@@ -1,0 +1,125 @@
+#Uncommenting these urls would only enable
+#the power up auto injection and force injection(test case).
+#XTRA_SERVER_1=http://xtrapath1.izatcloud.net/xtra2.bin
+#XTRA_SERVER_2=http://xtrapath2.izatcloud.net/xtra2.bin
+#XTRA_SERVER_3=http://xtrapath3.izatcloud.net/xtra2.bin
+
+#Version check for XTRA
+#DISABLE = 0
+#AUTO    = 1
+#XTRA2   = 2
+#XTRA3   = 3
+XTRA_VERSION_CHECK=0
+
+# Error Estimate
+# _SET = 1
+# _CLEAR = 0
+ERR_ESTIMATE=0
+
+#Test
+NTP_SERVER=time.gpsonextra.net
+#Asia
+# NTP_SERVER=asia.pool.ntp.org
+#Europe
+# NTP_SERVER=europe.pool.ntp.org
+#North America
+# NTP_SERVER=north-america.pool.ntp.org
+
+# DEBUG LEVELS: 0 - none, 1 - Error, 2 - Warning, 3 - Info
+#               4 - Debug, 5 - Verbose
+# If DEBUG_LEVEL is commented, Android's logging levels will be used
+DEBUG_LEVEL = 2
+
+# Intermediate position report, 1=enable, 0=disable
+INTERMEDIATE_POS=0
+
+# Below bit mask configures how GPS functionalities
+# should be locked when user turns off GPS on Settings
+# Set bit 0x1 if MO GPS functionalities are to be locked
+# Set bit 0x2 if NI GPS functionalities are to be locked
+# default - non is locked for backward compatibility
+#GPS_LOCK = 0
+
+# supl version 1.0
+SUPL_VER=0x10000
+
+# Emergency SUPL, 1=enable, 0=disable
+SUPL_ES=1
+
+#Choose PDN for Emergency SUPL
+#1 - Use emergency PDN
+#0 - Use regular SUPL PDN for Emergency SUPL
+USE_EMERGENCY_PDN_FOR_EMERGENCY_SUPL=1
+
+#SUPL_MODE is a bit mask set in config.xml per carrier by default.
+#If it is uncommented here, this value will over write the value from
+#config.xml.
+#MSA=0X2
+#MSB=0X1
+#SUPL_MODE=
+
+# GPS Capabilities bit mask
+# SCHEDULING = 0x01
+# MSB = 0x02
+# MSA = 0x04
+# ON_DEMAND_TIME = 0x10
+# GEOFENCE = 0x20
+# default = ON_DEMAND_TIME | MSA | MSB | SCHEDULING | GEOFENCE
+CAPABILITIES=0x13
+
+# Accuracy threshold for intermediate positions
+# less accurate positions are ignored, 0 for passing all positions
+# ACCURACY_THRES=5000
+
+################################
+##### AGPS server settings #####
+################################
+
+# FOR SUPL SUPPORT, set the following
+SUPL_HOST=supl.sonyericsson.com
+SUPL_PORT=7275
+
+# FOR C2K PDE SUPPORT, set the following
+# C2K_HOST=c2k.pde.com or IP
+# C2K_PORT=1234
+
+# Bitmask of slots that are available
+# for write/install to, where 1s indicate writable,
+# and the default value is 0 where no slots
+# are writable. For example, AGPS_CERT_WRITABLE_MASK
+# of b1000001010 makes 3 slots available
+# and the remaining 7 slots unwritable.
+#AGPS_CERT_WRITABLE_MASK=0
+
+####################################
+#  LTE Positioning Profile Settings
+####################################
+# 0: Enable RRLP on LTE(Default)
+# 1: Enable LPP_User_Plane on LTE
+# 2: Enable LPP_Control_Plane
+# 3: Enable both LPP_User_Plane and LPP_Control_Plane
+LPP_PROFILE = 0
+
+################################
+# EXTRA SETTINGS
+################################
+# NMEA provider (1=Modem Processor, 0=Application Processor)
+NMEA_PROVIDER=0
+# Mark if it is a SGLTE target (1=SGLTE, 0=nonSGLTE)
+SGLTE_TARGET=0
+
+##################################################
+# Select Positioning Protocol on A-GLONASS system
+##################################################
+# 0x1: RRC CPlane
+# 0x2: RRLP UPlane
+# 0x4: LLP Uplane
+A_GLONASS_POS_PROTOCOL_SELECT = 0x2
+
+###########################################
+# Enable/Disable reading H-SLP address and
+# certificates from the SIM card
+###########################################
+# 0: Disable (Default)
+# 1: Enable
+ENABLE_READ_FROM_SIM = 0

--- a/gps/gps.conf
+++ b/gps/gps.conf
@@ -1,15 +1,13 @@
-#Uncommenting these urls would only enable
-#the power up auto injection and force injection(test case).
-#XTRA_SERVER_1=http://xtrapath1.izatcloud.net/xtra2.bin
-#XTRA_SERVER_2=http://xtrapath2.izatcloud.net/xtra2.bin
-#XTRA_SERVER_3=http://xtrapath3.izatcloud.net/xtra2.bin
-
-#Version check for XTRA
-#DISABLE = 0
-#AUTO    = 1
-#XTRA2   = 2
-#XTRA3   = 3
-XTRA_VERSION_CHECK=0
+# XTRA_SERVER_QUERY (1=on, 0=off)
+# If XTRA_SERVER_QUERY is on, the XTRA_SERVERs listed
+# below will be ignored, and instead the servers will
+# be queried from the modem.
+XTRA_SERVER_QUERY=0
+# XTRA_SERVERs below are used only if XTRA_SERVER_QUERY
+# is off.
+XTRA_SERVER_1=http://xtrapath1.izatcloud.net/xtra2.bin
+XTRA_SERVER_2=http://xtrapath2.izatcloud.net/xtra2.bin
+XTRA_SERVER_3=http://xtrapath3.izatcloud.net/xtra2.bin
 
 # Error Estimate
 # _SET = 1
@@ -17,7 +15,7 @@ XTRA_VERSION_CHECK=0
 ERR_ESTIMATE=0
 
 #Test
-NTP_SERVER=time.gpsonextra.net
+NTP_SERVER=time.izatcloud.net
 #Asia
 # NTP_SERVER=asia.pool.ntp.org
 #Europe
@@ -28,35 +26,16 @@ NTP_SERVER=time.gpsonextra.net
 # DEBUG LEVELS: 0 - none, 1 - Error, 2 - Warning, 3 - Info
 #               4 - Debug, 5 - Verbose
 # If DEBUG_LEVEL is commented, Android's logging levels will be used
-DEBUG_LEVEL = 2
+DEBUG_LEVEL = 0
 
 # Intermediate position report, 1=enable, 0=disable
 INTERMEDIATE_POS=0
 
-# Below bit mask configures how GPS functionalities
-# should be locked when user turns off GPS on Settings
-# Set bit 0x1 if MO GPS functionalities are to be locked
-# Set bit 0x2 if NI GPS functionalities are to be locked
-# default - non is locked for backward compatibility
-#GPS_LOCK = 0
-
-# supl version 1.0
-SUPL_VER=0x10000
+# supl version 2.0
+SUPL_VER=0x20000
 
 # Emergency SUPL, 1=enable, 0=disable
 SUPL_ES=1
-
-#Choose PDN for Emergency SUPL
-#1 - Use emergency PDN
-#0 - Use regular SUPL PDN for Emergency SUPL
-USE_EMERGENCY_PDN_FOR_EMERGENCY_SUPL=1
-
-#SUPL_MODE is a bit mask set in config.xml per carrier by default.
-#If it is uncommented here, this value will over write the value from
-#config.xml.
-#MSA=0X2
-#MSB=0X1
-#SUPL_MODE=
 
 # GPS Capabilities bit mask
 # SCHEDULING = 0x01
@@ -64,8 +43,8 @@ USE_EMERGENCY_PDN_FOR_EMERGENCY_SUPL=1
 # MSA = 0x04
 # ON_DEMAND_TIME = 0x10
 # GEOFENCE = 0x20
-# default = ON_DEMAND_TIME | MSA | MSB | SCHEDULING | GEOFENCE
-CAPABILITIES=0x13
+# default = ON_DEMAND_TIME | MSA | MSB | SCHEDULING
+CAPABILITIES=0x3
 
 # Accuracy threshold for intermediate positions
 # less accurate positions are ignored, 0 for passing all positions
@@ -83,14 +62,6 @@ SUPL_PORT=7275
 # C2K_HOST=c2k.pde.com or IP
 # C2K_PORT=1234
 
-# Bitmask of slots that are available
-# for write/install to, where 1s indicate writable,
-# and the default value is 0 where no slots
-# are writable. For example, AGPS_CERT_WRITABLE_MASK
-# of b1000001010 makes 3 slots available
-# and the remaining 7 slots unwritable.
-#AGPS_CERT_WRITABLE_MASK=0
-
 ####################################
 #  LTE Positioning Profile Settings
 ####################################
@@ -104,7 +75,7 @@ LPP_PROFILE = 0
 # EXTRA SETTINGS
 ################################
 # NMEA provider (1=Modem Processor, 0=Application Processor)
-NMEA_PROVIDER=0
+NMEA_PROVIDER=1
 # Mark if it is a SGLTE target (1=SGLTE, 0=nonSGLTE)
 SGLTE_TARGET=0
 
@@ -114,12 +85,4 @@ SGLTE_TARGET=0
 # 0x1: RRC CPlane
 # 0x2: RRLP UPlane
 # 0x4: LLP Uplane
-A_GLONASS_POS_PROTOCOL_SELECT = 0x2
-
-###########################################
-# Enable/Disable reading H-SLP address and
-# certificates from the SIM card
-###########################################
-# 0: Disable (Default)
-# 1: Enable
-ENABLE_READ_FROM_SIM = 0
+A_GLONASS_POS_PROTOCOL_SELECT = 0

--- a/msm8974.mk
+++ b/msm8974.mk
@@ -91,7 +91,8 @@ PRODUCT_COPY_FILES += \
 
 # Permissions
 PRODUCT_COPY_FILES += \
-    frameworks/native/data/etc/android.hardware.ethernet.xml:system/etc/permissions/android.hardware.ethernet.xml
+    frameworks/native/data/etc/android.hardware.ethernet.xml:system/etc/permissions/android.hardware.ethernet.xml \
+    frameworks/native/data/etc/android.hardware.location.gps.xml:system/etc/permissions/android.hardware.location.gps.xml
 
 # Omx
 PRODUCT_PACKAGES += \
@@ -110,7 +111,15 @@ PRODUCT_PACKAGES += \
 
 # GPS
 PRODUCT_PACKAGES += \
-    gps.msm8974
+    gps.msm8974 \
+    libloc_core \
+    libloc_eng \
+    libgps.utils \
+    libloc_ds_api \
+    libloc_api_v02
+
+PRODUCT_COPY_FILES += \
+    $(COMMON_PATH)/gps/gps.conf:system/etc/gps.conf
 
 # Overlay
 DEVICE_PACKAGE_OVERLAYS += $(COMMON_PATH)/overlay

--- a/rootdir/init.msm8974-common.rc
+++ b/rootdir/init.msm8974-common.rc
@@ -303,17 +303,8 @@ on post-fs-data
 
     chown system system /sys/devices/platform/kgsl-3d0.0/kgsl/kgsl-3d0/pwrscale/policy
 
-    # Create directories for gpsone_daemon services
-    mkdir /data/misc/gpsone_d 0770 system gps
-
-    # Create directories for QuIPS
-    mkdir /data/misc/quipc 0770 gps system
-
     # Create directories for Location services
     mkdir /data/misc/location 0770 gps gps
-    mkdir /data/misc/location/mq 0770 gps gps
-    mkdir /data/misc/location/xtwifi 0770 gps gps
-    mkdir /data/misc/location/gsiff 0770 gps gps
 
     # Provide the access to hostapd.conf only to root and group
     chmod 0660 /data/hostapd/hostapd.conf
@@ -377,11 +368,6 @@ service qseecomd /system/bin/qseecomd
 on property:ro.data.large_tcp_window_size=true
     # Adjust socket buffer to enlarge TCP receive window for high bandwidth (e.g. DO-RevB)
     write /proc/sys/net/ipv4/tcp_adv_win_scale 2
-
-service loc_launcher /system/bin/loc_launcher
-    #loc_launcher will start as root and set its uid to gps
-    class late_start
-    group gps inet net_raw qcom_diag net_admin wifi
 
 # Start suntrold
 service suntrold /system/bin/suntrold

--- a/systemprop.mk
+++ b/systemprop.mk
@@ -58,11 +58,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     dalvik.vm.dex2oat-threads=2 \
     dalvik.vm.image-dex2oat-threads=4
 
-# GPS
-PRODUCT_PROPERTY_OVERRIDES += \
-    persist.gps.qc_nlp_in_use=0 \
-    ro.gps.agps_provider=1
-
 # Touchscreen
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.input.noresample=1


### PR DESCRIPTION
Changes GPS to full aosp halls
Needs changes in:

- msm8974-common
- rhine-common
- hardware/qcom/gps <- should delete msm8974. Using the old way
- needs https://github.com/sonyxperiadev/vendor-qcom-opensource-location or update lineage one

We could add proprietary geofence back into the mix. Don't know if it has an effect on the gps lock

Fixes gps and gets a fix in around 10-20s